### PR TITLE
Fix for premature dedupe on repository

### DIFF
--- a/kastle-core/src/commonMain/kotlin/BuildSystemTypes.kt
+++ b/kastle-core/src/commonMain/kotlin/BuildSystemTypes.kt
@@ -305,14 +305,7 @@ fun SourceModule.tryMerge(other: SourceModule): SourceModule? {
     return manifest.tryMerge(other.manifest)?.let { manifest ->
         SourceModule(
             manifest = manifest,
-            sources = (sources + other.sources).also { mergedSources ->
-                val uniquePaths = mutableSetOf<StringExpression>()
-                mergedSources.forEach {
-                    require(it.target.protocol != "file" || uniquePaths.add(it.target)) {
-                        "Duplicate file: ${it.target}"
-                    }
-                }
-            }
+            sources = sources + other.sources
         )
     }
 }

--- a/kastle-core/src/commonMain/kotlin/ProjectGenerator.kt
+++ b/kastle-core/src/commonMain/kotlin/ProjectGenerator.kt
@@ -65,6 +65,7 @@ class ProjectGenerator(
             }
             val outputtedPaths = mutableSetOf<String>()
             val slotSources = slotSources + module.slotSources
+            val visitedPaths = mutableSetOf<String>()
 
             for (source in moduleSources) {
                 val path = getActualPath(source, module)
@@ -73,14 +74,14 @@ class ProjectGenerator(
                     continue
                 }
                 val variables = collectVariables(packId, module)
-
-                source.condition?.evaluate(variables)?.let { conditionResult ->
-                    if (!conditionResult.isTruthy()) {
-                        log.debug { "Skipping ${source.target}; ${source.condition} = $conditionResult" }
-                        continue
-                    } else {
-                        log.trace { "Include ${source.target}; ${source.condition} = $conditionResult" }
-                    }
+                if (source.condition != null && !source.condition?.evaluate(variables).isTruthy()) {
+                    log.debug { "Skipping ${source.target}; ${source.condition} = ${source.condition?.evaluate(variables)}" }
+                    continue
+                } else if (!visitedPaths.add(path)) {
+                    log.debug { "Skipping ${source.target}; duplicate path $path" }
+                    continue
+                } else {
+                    log.trace { "Include ${source.target}; ${source.condition} = ${source.condition?.evaluate(variables)}" }
                 }
 
                 if (source !is SourceTemplate) {

--- a/kastle-local/src/main/kotlin/LocalPackRepository.kt
+++ b/kastle-local/src/main/kotlin/LocalPackRepository.kt
@@ -426,7 +426,8 @@ class LocalPackRepository(
     }
 
     /**
-     * Allows for overriding details for files under src dir.
+     * Allows for overriding details for files under src dir. Preference is given to
+     * entries with conditions.
      *
      * Slots are allowed to be duplicate, so they are ignored.
      */
@@ -434,8 +435,12 @@ class LocalPackRepository(
         groupBy { it.target }
             .flatMap { (target, files) ->
                 when(target.protocol) {
-                    // The last entry is always provided in the manifest
-                    "file" -> files.subList(files.size - 1, files.size)
+                    "file" -> when(files.size) {
+                        1 -> files
+                        else -> files.filter { it.condition != null }.ifEmpty {
+                            files.subList(files.size - 1, files.size)
+                        }
+                    }
                     "slot" -> files
                     else -> error("Unknown protocol: ${target.protocol}")
                 }


### PR DESCRIPTION
Now, we'll always retain module sources with conditions, even when duplicated.  If more than one match on a path during generation, the first one will win.