### PR TITLE
Fix slots invocation call reference in DSL

### DIFF
--- a/kastle-templates/api/kastle-templates.api
+++ b/kastle-templates/api/kastle-templates.api
@@ -5,7 +5,7 @@ public final class kastle/DSLKt {
 	public static final fun get_project ()Lkastle/TemplateProject;
 	public static final fun get_properties ()Lkastle/TemplateProperties;
 	public static final fun get_slot ()Lkotlin/jvm/functions/Function1;
-	public static final fun get_slots ()Ljava/util/Map;
+	public static final fun get_slots ()Lkastle/TemplateSlots;
 }
 
 public final class kastle/TemplateAmperApplicationSettings {
@@ -415,6 +415,10 @@ public final class kastle/TemplateProperties$DefaultImpls {
 
 public abstract interface class kastle/TemplateSlot {
 	public abstract fun get ()Ljava/lang/Object;
+}
+
+public abstract interface class kastle/TemplateSlots : java/util/Map, kotlin/jvm/internal/markers/KMappedMarker {
+	public abstract fun invoke (Ljava/lang/String;)V
 }
 
 public final class kastle/TemplateSourceModule {

--- a/kastle-templates/api/kastle-templates.klib.api
+++ b/kastle-templates/api/kastle-templates.klib.api
@@ -19,6 +19,10 @@ abstract interface kastle/TemplateSlot { // kastle/TemplateSlot|null[0]
     abstract fun <#A1: kotlin/Any?> get(): #A1 // kastle/TemplateSlot.get|get(){0§<kotlin.Any?>}[0]
 }
 
+abstract interface kastle/TemplateSlots : kotlin.collections/Map<kotlin/String, kotlin.collections/List<kastle/TemplateSlot>> { // kastle/TemplateSlots|null[0]
+    abstract fun invoke(kotlin/String) // kastle/TemplateSlots.invoke|invoke(kotlin.String){}[0]
+}
+
 final class kastle/TemplateAmperApplicationSettings { // kastle/TemplateAmperApplicationSettings|null[0]
     constructor <init>(kotlin/String? = ...) // kastle/TemplateAmperApplicationSettings.<init>|<init>(kotlin.String?){}[0]
 
@@ -492,6 +496,6 @@ final val kastle/_properties // kastle/_properties|{}_properties[0]
 final val kastle/_slot // kastle/_slot|{}_slot[0]
     final fun <get-_slot>(): kotlin/Function1<kotlin/String, kastle/TemplateSlot?> // kastle/_slot.<get-_slot>|<get-_slot>(){}[0]
 final val kastle/_slots // kastle/_slots|{}_slots[0]
-    final fun <get-_slots>(): kotlin.collections/Map<kotlin/String, kotlin.collections/List<kastle/TemplateSlot>> // kastle/_slots.<get-_slots>|<get-_slots>(){}[0]
+    final fun <get-_slots>(): kastle/TemplateSlots // kastle/_slots.<get-_slots>|<get-_slots>(){}[0]
 
 final fun <#A: kotlin/Any?> kastle/_unsafe(kotlin/String): #A // kastle/_unsafe|_unsafe(kotlin.String){0§<kotlin.Any?>}[0]

--- a/kastle-templates/src/commonMain/kotlin/DSL.kt
+++ b/kastle-templates/src/commonMain/kotlin/DSL.kt
@@ -36,12 +36,16 @@ val _slot: (String) -> TemplateSlot? = { null }
 /**
  * Injects all slots targeting the given slot name.
  */
-val _slots: Map<String, List<TemplateSlot>> = emptyMap()
+val _slots: TemplateSlots = TODO(RUNTIME_ERROR)
 
 /**
  * Inlines the string as raw code.
  */
 fun <E> _unsafe(code: String): E = TODO(RUNTIME_ERROR)
+
+interface TemplateSlots: Map<String, List<TemplateSlot>> {
+    operator fun invoke(key: String)
+}
 
 interface TemplateProperties {
     operator fun <T> getValue(thisRef: Any?, property: KProperty<*>): T = TODO(RUNTIME_ERROR)


### PR DESCRIPTION
Removed DSL for `_slots("key")` accidentally.