### PR TITLE
Upgrade template engine to K2

### DIFF
--- a/kastle-local/src/main/kotlin/templates/KotlinCompilerTemplateEngine.kt
+++ b/kastle-local/src/main/kotlin/templates/KotlinCompilerTemplateEngine.kt
@@ -21,11 +21,15 @@ import org.jetbrains.kotlin.K1Deprecation
 import org.jetbrains.kotlin.cli.common.config.addKotlinSourceRoot
 import org.jetbrains.kotlin.cli.common.messages.MessageRenderer
 import org.jetbrains.kotlin.cli.common.messages.PrintingMessageCollector
-import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
+import org.jetbrains.kotlin.cli.jvm.K2JVMCompiler
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.jetbrains.kotlin.config.ApiVersion
 import org.jetbrains.kotlin.config.CommonConfigurationKeys
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.JVMConfigurationKeys
+import org.jetbrains.kotlin.config.LanguageFeature
+import org.jetbrains.kotlin.config.LanguageVersion
+import org.jetbrains.kotlin.config.LanguageVersionSettingsImpl
 import org.jetbrains.kotlin.idea.KotlinFileType
 import org.jetbrains.kotlin.lexer.KtSingleValueToken
 import org.jetbrains.kotlin.psi.KtElement
@@ -64,19 +68,33 @@ internal class KotlinCompilerTemplateEngine(
             put(CommonConfigurationKeys.MESSAGE_COLLECTOR_KEY, stderrMessages)
             path?.parent?.name?.let { put(CommonConfigurationKeys.MODULE_NAME, it) }
             put(CommonConfigurationKeys.ALLOW_ANY_SCRIPTS_IN_SOURCE_ROOTS, true)
+            put(CommonConfigurationKeys.LANGUAGE_VERSION_SETTINGS, k2LanguageVersionSettings())
+            put(CommonConfigurationKeys.USE_FIR, true)
+            put(CommonConfigurationKeys.USE_LIGHT_TREE, false)
             put(JVMConfigurationKeys.JDK_HOME, File(System.getenv("JAVA_HOME")))
 
             path?.let { addKotlinSourceRoot(path.toString()) }
         }
         @OptIn(K1Deprecation::class)
-        environment = KotlinCoreEnvironment.createForProduction(
+        environment = K2JVMCompiler.createCoreEnvironment(
             Disposer.newDisposable(),
             configuration,
-            EnvironmentConfigFiles.JVM_CONFIG_FILES
-        )
+            stderrMessages,
+            configuration.get(CommonConfigurationKeys.MODULE_NAME) ?: "kastle-template"
+        ) ?: error("Failed to create K2 Kotlin compiler environment")
         psiFileFactory = PsiFileFactory.getInstance(environment.project)
         expressionParser = KotlinExpressionParser(psiFileFactory)
     }
+
+    private fun k2LanguageVersionSettings(): LanguageVersionSettingsImpl =
+        LanguageVersion.LATEST_STABLE.let { languageVersion ->
+            LanguageVersionSettingsImpl(
+                languageVersion = languageVersion,
+                apiVersion = ApiVersion.createByLanguageVersion(languageVersion),
+                analysisFlags = emptyMap(),
+                specificFeatures = mapOf(LanguageFeature.ContextParameters to LanguageFeature.State.ENABLED),
+            )
+        }
 
     val ktFiles: List<KtFile> by lazy {
         environment.getSourceFiles()

--- a/kastle-local/src/test/kotlin/templates/KotlinCompilerTemplateEngineTest.kt
+++ b/kastle-local/src/test/kotlin/templates/KotlinCompilerTemplateEngineTest.kt
@@ -7,6 +7,8 @@ import org.jetbrains.kastle.SourceTemplate
 import org.jetbrains.kastle.TemplateEvaluator.Companion.toString
 import org.jetbrains.kastle.utils.LocalVariables
 import org.jetbrains.kastle.utils.Variables
+import org.jetbrains.kotlin.config.CommonConfigurationKeys
+import org.jetbrains.kotlin.config.LanguageFeature
 
 class KotlinCompilerTemplateEngineTest : StringSpec({
 
@@ -18,6 +20,16 @@ class KotlinCompilerTemplateEngineTest : StringSpec({
 
     fun template(text: String): SourceTemplate =
         engine.read(text = text)
+
+    "uses K2 compiler front-end configuration" {
+        engine.environment.configuration.get(CommonConfigurationKeys.USE_FIR) shouldBe true
+        engine.environment.configuration.get(CommonConfigurationKeys.USE_LIGHT_TREE) shouldBe false
+        engine.environment.configuration
+            .get(CommonConfigurationKeys.LANGUAGE_VERSION_SETTINGS)!!
+            .also { it.getFeatureSupport(LanguageFeature.ContextParameters) shouldBe LanguageFeature.State.ENABLED }
+            .languageVersion
+            .usesK2 shouldBe true
+    }
 
     "literals" {
         val template = template("""
@@ -32,6 +44,20 @@ class KotlinCompilerTemplateEngineTest : StringSpec({
         template.toString(
             variables = localVars("title" to "Hello, World!")
         ) shouldBe "\nval html = html {\n    h1 {\n        +\"Hello, World!\"\n    }\n}"
+    }
+
+    "context parameter syntax" {
+        val template = template("""
+            val title: String by _properties
+            context(_: String)
+            fun render() {
+                println(title)
+            }
+        """.trimIndent())
+
+        template.toString(
+            variables = localVars("title" to "Hello, K2!")
+        ) shouldBe "\ncontext(_: String)\nfun render() {\n    println(\"Hello, K2!\")\n}"
     }
 
     "string interpolation" {


### PR DESCRIPTION
Updates the Kotlin compiler template engine to create a K2/FIR compiler environment while keeping PSI-backed source parsing for template comments, offsets, and block detection.

I also added coverage for the K2 compiler configuration and context parameter syntax so the engine does not accidentally fall back to the old frontend path.

Tests:
- ./gradlew :kastle-local:test --tests org.jetbrains.kastle.templates.KotlinCompilerTemplateEngineTest
- ./gradlew :kastle-local:jvmTest
- ./gradlew test

Closes #63