### PR TITLE
Improve test failure message

### DIFF
--- a/kastle-test/src/commonMain/kotlin/TestUtils.kt
+++ b/kastle-test/src/commonMain/kotlin/TestUtils.kt
@@ -85,7 +85,7 @@ fun assertFilesAreEqual(
     if (!ignoreListing) {
         val actualListing = actualFiles.joinToString("\n")
         val expectedListing = expectedFiles.joinToString("\n")
-        actualListing shouldBe expectedListing
+        actualListing.shouldBe(expectedListing, "File listing differs")
     }
 
     for (relativePath in expectedFiles) {
@@ -95,7 +95,7 @@ fun assertFilesAreEqual(
         val expectedContents = readText(expectedFile, fs).normalize()
         val actualContents = readText(actualFile, fs).normalize()
 
-        actualContents shouldBe expectedContents
+        actualContents.shouldBe(expectedContents, "File $relativePath differs")
     }
 }
 


### PR DESCRIPTION
To avoid manual checking of what failed, which currently must be done by searching for the file content in templates.