### PR TITLE
Fix package in Amper test sources

### DIFF
--- a/kastle-core/src/commonMain/kotlin/kotlin/KotlinSupport.kt
+++ b/kastle-core/src/commonMain/kotlin/kotlin/KotlinSupport.kt
@@ -22,7 +22,7 @@ fun Appendable.writeKotlinSourcePreamble(
     skipPackage: Boolean,
 ): Int {
     val dir = target.parentPath
-        .replace(Regex("^/?/?(?:src(?:@\\w+)?)?(?:/\\w*(?:main|test)/\\w+)?/?", RegexOption.IGNORE_CASE), "")
+        .replace(Regex("^/?/?(?:(?:src|test)(?:@\\w+)?)?(?:/\\w*(?:main|test)/\\w+)?/?", RegexOption.IGNORE_CASE), "")
         .replace('/', '.')
         .removePrefix(groupId) // when using nested structure
 

--- a/testSnapshots/ktor-server-amper/test/ServerTest.kt
+++ b/testSnapshots/ktor-server-amper/test/ServerTest.kt
@@ -1,4 +1,4 @@
-package com.acme.test
+package com.acme
 
 import io.ktor.client.request.get
 import io.ktor.http.HttpStatusCode


### PR DESCRIPTION
A "test" package was being appended due to a faulty regex in the package inference.