### PR TITLE
Support nested source paths in package calcuation

### DIFF
--- a/kastle-core/src/commonMain/kotlin/kotlin/KotlinSupport.kt
+++ b/kastle-core/src/commonMain/kotlin/kotlin/KotlinSupport.kt
@@ -21,10 +21,15 @@ fun Appendable.writeKotlinSourcePreamble(
     extraImports: List<SourceImport>,
     skipPackage: Boolean,
 ): Int {
-    val dir = target.parentPath
-        .replace(Regex("^/?/?(?:(?:src|test)(?:@\\w+)?)?(?:/\\w*(?:main|test)/\\w+)?/?", RegexOption.IGNORE_CASE), "")
+    val dir = Regex("(?:(?:src|test)(?:@\\w+)?)?/\\w*(?:main|test)/\\w+/?", RegexOption.IGNORE_CASE)
+        // find a match in input (src/commonMain/kotlin in src/commonMain/kotlin/com/example):
+        .find(target.parentPath)
+        // delete the source root part (src/commonMain/kotlin/com/example → com/example):
+        ?.let { target.parentPath.substring(it.range.last + 1) }.orEmpty()
+        // convert to package notation (com/example → com.example):
         .replace('/', '.')
-        .removePrefix(groupId) // when using nested structure
+        // avoid duplicating groupId when the directory structure mirrors it (com.example → "" so pkg = groupId):
+        .removePrefix(groupId)
 
     val pkg = if (dir.isEmpty()) groupId else "${groupId}.$dir"
 


### PR DESCRIPTION
This allows for proper package calculation in cases when sources are nested in a pack's directories, in our case:
```
- pack
  - dir1
    - src
  - dir2
    - src
```
We render dir1 or dir2 depending on some conditions.

I also added more descriptive comments, for clarity.