### PR TITLE
Fix export samples

### DIFF
--- a/kastle-server-jib/build.gradle.kts
+++ b/kastle-server-jib/build.gradle.kts
@@ -5,10 +5,9 @@ plugins {
 
 val exportDir = rootDir.resolve("export")
 
-tasks.register<GradleBuild>("exportSamples") {
-    dir = rootDir.resolve("testTemplates")
-    tasks = listOf("kslExportToCbor")
-    startParameter.projectProperties["exportPath"] = exportDir.absolutePath
+val exportSamples by tasks.registering(Exec::class) {
+    workingDir = rootDir.resolve("testTemplates")
+    commandLine("./gradlew", "kslExportToCbor", "-PexportPath=${exportDir.absolutePath}")
 }
 
 tasks.jib {

--- a/testTemplates/settings.gradle.kts
+++ b/testTemplates/settings.gradle.kts
@@ -14,19 +14,12 @@ pluginManagement {
         gradlePluginPortal()
         mavenLocal()
     }
-    // Substitute the published `org.jetbrains.kastle` Gradle plugin with the
-    // local `kastle-gradle-plugin` module from the parent `kastle` build, so
-    // this build never depends on the plugin being published to mavenLocal
-    // or the plugin portal. Including the parent build also pulls in
-    // `kastle-core`, `kastle-local`, and `kastle-server` (the plugin's
-    // runtime dependencies) via composite-build dependency substitution.
     includeBuild("..")
 }
 
 plugins {
     id("org.jetbrains.kastle") version "1.0.0-SNAPSHOT"
 }
-
 dependencyResolutionManagement {
     repositories {
         google {


### PR DESCRIPTION
We can't invoke gradle tasks on the templates build script directly because it presents a recursive problem.  To get around this, we'll just invoke the build as an external script.