### PR TITLE
Unused import handling

### DIFF
--- a/kastle-core/api/kastle-core.api
+++ b/kastle-core/api/kastle-core.api
@@ -1890,6 +1890,7 @@ public final class org/jetbrains/kastle/SourceFileEntry {
 
 public abstract interface class org/jetbrains/kastle/SourceImport {
 	public static final field Companion Lorg/jetbrains/kastle/SourceImport$Companion;
+	public abstract fun getValue ()Ljava/lang/String;
 }
 
 public final class org/jetbrains/kastle/SourceImport$Companion {
@@ -1904,7 +1905,7 @@ public final class org/jetbrains/kastle/SourceImport$External : org/jetbrains/ka
 	public fun equals (Ljava/lang/Object;)Z
 	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
 	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
-	public final fun getValue ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
 	public fun hashCode ()I
 	public static fun hashCode-impl (Ljava/lang/String;)I
 	public fun toString ()Ljava/lang/String;
@@ -1934,7 +1935,7 @@ public final class org/jetbrains/kastle/SourceImport$Module : org/jetbrains/kast
 	public fun equals (Ljava/lang/Object;)Z
 	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
 	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
-	public final fun getValue ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
 	public fun hashCode ()I
 	public static fun hashCode-impl (Ljava/lang/String;)I
 	public fun toString ()Ljava/lang/String;
@@ -3290,6 +3291,17 @@ public final synthetic class org/jetbrains/kastle/utils/Expression$VariableRef$$
 
 public final class org/jetbrains/kastle/utils/Expression$VariableRef$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jetbrains/kastle/utils/ImportTrackingAppendable : java/lang/Appendable {
+	public fun <init> (Lorg/jetbrains/kastle/SourceImports;)V
+	public synthetic fun append (C)Ljava/lang/Appendable;
+	public fun append (C)Lorg/jetbrains/kastle/utils/ImportTrackingAppendable;
+	public synthetic fun append (Ljava/lang/CharSequence;)Ljava/lang/Appendable;
+	public fun append (Ljava/lang/CharSequence;)Lorg/jetbrains/kastle/utils/ImportTrackingAppendable;
+	public synthetic fun append (Ljava/lang/CharSequence;II)Ljava/lang/Appendable;
+	public fun append (Ljava/lang/CharSequence;II)Lorg/jetbrains/kastle/utils/ImportTrackingAppendable;
+	public final fun filterUnused ()Lorg/jetbrains/kastle/SourceImports;
 }
 
 public final class org/jetbrains/kastle/utils/ListQueue : org/jetbrains/kastle/utils/Queue {

--- a/kastle-core/api/kastle-core.klib.api
+++ b/kastle-core/api/kastle-core.klib.api
@@ -1167,6 +1167,9 @@ sealed interface org.jetbrains.kastle/SourceFile { // org.jetbrains.kastle/Sourc
 }
 
 sealed interface org.jetbrains.kastle/SourceImport { // org.jetbrains.kastle/SourceImport|null[0]
+    abstract val value // org.jetbrains.kastle/SourceImport.value|{}value[0]
+        abstract fun <get-value>(): kotlin/String // org.jetbrains.kastle/SourceImport.value.<get-value>|<get-value>(){}[0]
+
     final value class External : org.jetbrains.kastle/SourceImport { // org.jetbrains.kastle/SourceImport.External|null[0]
         constructor <init>(kotlin/String) // org.jetbrains.kastle/SourceImport.External.<init>|<init>(kotlin.String){}[0]
 
@@ -1506,6 +1509,15 @@ final class org.jetbrains.kastle.utils/BufferAppendable : kotlin.text/Appendable
     final fun append(kotlin/Char): kotlin.text/Appendable // org.jetbrains.kastle.utils/BufferAppendable.append|append(kotlin.Char){}[0]
     final fun append(kotlin/CharSequence?): kotlin.text/Appendable // org.jetbrains.kastle.utils/BufferAppendable.append|append(kotlin.CharSequence?){}[0]
     final fun append(kotlin/CharSequence?, kotlin/Int, kotlin/Int): kotlin.text/Appendable // org.jetbrains.kastle.utils/BufferAppendable.append|append(kotlin.CharSequence?;kotlin.Int;kotlin.Int){}[0]
+}
+
+final class org.jetbrains.kastle.utils/ImportTrackingAppendable : kotlin.text/Appendable { // org.jetbrains.kastle.utils/ImportTrackingAppendable|null[0]
+    constructor <init>(org.jetbrains.kastle/SourceImports) // org.jetbrains.kastle.utils/ImportTrackingAppendable.<init>|<init>(org.jetbrains.kastle.SourceImports){}[0]
+
+    final fun append(kotlin/Char): org.jetbrains.kastle.utils/ImportTrackingAppendable // org.jetbrains.kastle.utils/ImportTrackingAppendable.append|append(kotlin.Char){}[0]
+    final fun append(kotlin/CharSequence?): org.jetbrains.kastle.utils/ImportTrackingAppendable // org.jetbrains.kastle.utils/ImportTrackingAppendable.append|append(kotlin.CharSequence?){}[0]
+    final fun append(kotlin/CharSequence?, kotlin/Int, kotlin/Int): org.jetbrains.kastle.utils/ImportTrackingAppendable // org.jetbrains.kastle.utils/ImportTrackingAppendable.append|append(kotlin.CharSequence?;kotlin.Int;kotlin.Int){}[0]
+    final fun filterUnused(): org.jetbrains.kastle/SourceImports // org.jetbrains.kastle.utils/ImportTrackingAppendable.filterUnused|filterUnused(){}[0]
 }
 
 final class org.jetbrains.kastle.utils/LocalVariables : org.jetbrains.kastle.utils/Variables { // org.jetbrains.kastle.utils/LocalVariables|null[0]

--- a/kastle-core/src/commonMain/kotlin/ProjectGenerator.kt
+++ b/kastle-core/src/commonMain/kotlin/ProjectGenerator.kt
@@ -70,17 +70,30 @@ class ProjectGenerator(
             }
         }
 
-        // 1. Dry run to validate configuration
+        // 1. Dry run to:
+        //  - validate configuration, and
+        //  - detect unused imports
+        val importOverrides = mutableMapOf<String, SourceImports?>()
         project.forEachTemplate { template ->
-            if (template is SourceTemplateIR.Parameters)
-                templateEvaluator.evaluateTo(template, DevNull)
+            if (template !is SourceTemplateIR.Parameters) return@forEachTemplate
+
+            val appendable = template.template.imports?.let(::ImportTrackingAppendable) ?: DevNull
+            templateEvaluator.evaluateTo(template, appendable)
+
+            (appendable as? ImportTrackingAppendable)?.filterUnused()?.let { unusedImports ->
+                importOverrides[template.path] = unusedImports
+            }
         }
 
         // 2. Write actual source file entries
         return flow {
             project.forEachTemplate { template ->
-                emit(SourceFileEntry(template.path) {
-                    templateEvaluator.evaluateToBuffer(template)
+                val effectiveTemplate = when {
+                    template !is SourceTemplateIR.Parameters || template.path !in importOverrides -> template
+                    else -> template.copy(template = template.template.copy(imports = importOverrides[template.path]))
+                }
+                emit(SourceFileEntry(effectiveTemplate.path) {
+                    templateEvaluator.evaluateToBuffer(effectiveTemplate)
                 })
             }
         }

--- a/kastle-core/src/commonMain/kotlin/TemplateTypes.kt
+++ b/kastle-core/src/commonMain/kotlin/TemplateTypes.kt
@@ -106,12 +106,14 @@ sealed interface SourceImport {
             else External(input)
     }
 
+    val value: String
+
     /**
      * A reference to another package from the KASTLE repository.
      */
     @Serializable
     @JvmInline
-    value class Module(val value: String): SourceImport {
+    value class Module(override val value: String): SourceImport {
         override fun toString(): String = "module: $value"
     }
 
@@ -120,7 +122,7 @@ sealed interface SourceImport {
      */
     @Serializable
     @JvmInline
-    value class External(val value: String): SourceImport {
+    value class External(override val value: String): SourceImport {
         override fun toString(): String = value
     }
 }

--- a/kastle-core/src/commonMain/kotlin/utils/Appendables.kt
+++ b/kastle-core/src/commonMain/kotlin/utils/Appendables.kt
@@ -3,6 +3,8 @@ package org.jetbrains.kastle.utils
 import kotlinx.io.Buffer
 import kotlinx.io.writeCodePointValue
 import kotlinx.io.writeString
+import org.jetbrains.kastle.SourceImport
+import org.jetbrains.kastle.SourceImports
 
 object DevNull: Appendable {
     override fun append(value: Char): Appendable = this
@@ -35,6 +37,66 @@ class BufferAppendable(val buffer: Buffer): Appendable {
         checkBounds(startIndex, endIndex, value)
         buffer.writeString(value, startIndex, endIndex)
         return this
+    }
+}
+
+/**
+ * Tracks which import symbols are actually referenced in the output body during a dry-run.
+ * Initialized with the template's imports; symbols are marked off as they're encountered
+ * in appended content. Import and package lines are skipped via regex. Wildcard imports
+ * are always retained since resolving them would require external dependencies.
+ */
+class ImportTrackingAppendable(private val imports: SourceImports) : Appendable {
+    private val preambleLine = Regex("^\\s*(import|package)\\s")
+
+    // Non-wildcard imports not yet seen in the output; removed as they're matched
+    private val pending: MutableMap<String, Pair<Regex, SourceImport>>
+
+    init {
+        val map = mutableMapOf<String, Pair<Regex, SourceImport>>()
+        for (import in imports.imports) {
+            val fqn = when (import) {
+                is SourceImport.Module -> import.value
+                is SourceImport.External -> import.value
+            }
+            if (!fqn.endsWith(".*")) {
+                val simpleName = fqn.substringAfterLast('.')
+                map[simpleName] = Regex("\\b${Regex.escape(simpleName)}\\b") to import
+            }
+        }
+        pending = map
+    }
+
+    override fun append(value: Char) = apply { scan(value.toString()) }
+    override fun append(value: CharSequence?) = apply { if (value != null) scan(value) }
+    override fun append(value: CharSequence?, startIndex: Int, endIndex: Int) = apply {
+        if (value != null) {
+            checkBounds(startIndex, endIndex, value)
+            scan(value, startIndex, endIndex)
+        }
+    }
+
+    private fun scan(content: CharSequence, start: Int = 0, end: Int = content.length) {
+        if (pending.isEmpty()) return
+        content.subSequence(start, end).split('\n').forEach { line ->
+            if (pending.isEmpty()) return
+            if (preambleLine.containsMatchIn(line)) return@forEach
+            val iter = pending.iterator()
+            while (iter.hasNext()) {
+                val (_, regexAndImport) = iter.next()
+                if (regexAndImport.first.containsMatchIn(line)) iter.remove()
+            }
+        }
+    }
+
+    /**
+     * Returns a copy of the original [imports] with unused symbols removed, or the
+     * same instance if nothing was filtered. Wildcards are never removed.
+     */
+    fun filterUnused(): SourceImports {
+        if (pending.isEmpty()) return imports
+        val unused = pending.values.mapTo(mutableSetOf()) { it.second }
+        return imports.copy(imports = imports.imports.filterNot { it in unused })
     }
 }
 


### PR DESCRIPTION
Because the template engine includes a lot of conditional blocks like `if`, `else` and `for`, unused imports are comment when sections are excluded.  This will ensure that only used imports are included, with the caveat that wildcard imports remain untouched.

Fixes #136 